### PR TITLE
Respect CXX and CXXFLAGS variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
-Cxx = g++
+CXX ?= g++
 
 
-CFLAGS = -O3 
-LFLAGS=  -lz
+CXXFLAGS ?= -O3
+LFLAGS = -lz
 
 all: mergeReads nxtrim
 
-debug: CFLAGS = -Wall -g 
+debug: CXXFLAGS += -Wall -g
 debug: all
 
 GIT_HASH := $(shell git describe --abbrev=4 --always )
@@ -21,17 +21,17 @@ version.h:
 
 
 unit_test: test.cpp fastqlib.o utilityfunc.o matepair.o
-	$(CXX) $(CFLAGS) test.cpp fastqlib.o utilityfunc.o matepair.o -o unit_test   $(LFLAGS)
+	$(CXX) $(CXXFLAGS) test.cpp fastqlib.o utilityfunc.o matepair.o -o unit_test   $(LFLAGS)
 nxtrim: nxtrim.cpp fastqlib.o utilityfunc.o matepair.o fastqlib.o version.h
-	$(CXX) $(CFLAGS) nxtrim.cpp fastqlib.o utilityfunc.o matepair.o -o nxtrim  $(LFLAGS)
+	$(CXX) $(CXXFLAGS) nxtrim.cpp fastqlib.o utilityfunc.o matepair.o -o nxtrim  $(LFLAGS)
 mergeReads: mergeReads.cpp fastqlib.o utilityfunc.o fastqlib.o githash.h version.h
-	$(CXX) $(CFLAGS)  mergeReads.cpp fastqlib.o utilityfunc.o -o mergeReads   $(LFLAGS)
+	$(CXX) $(CXXFLAGS)  mergeReads.cpp fastqlib.o utilityfunc.o -o mergeReads   $(LFLAGS)
 matepair.o: matepair.cpp matepair.h fastqlib.h
-	$(CXX) $(CFLAGS) -c matepair.cpp
+	$(CXX) $(CXXFLAGS) -c matepair.cpp
 fastqlib.o: fastqlib.cpp fastqlib.h utilityfunc.h
-	$(CXX) $(CFLAGS) -c fastqlib.cpp
+	$(CXX) $(CXXFLAGS) -c fastqlib.cpp
 utilityfunc.o:  utilityfunc.cpp utilityfunc.h
-	$(CXX) $(CFLAGS) -c utilityfunc.cpp 
+	$(CXX) $(CXXFLAGS) -c utilityfunc.cpp
 test: nxtrim
 	bash example/run_test.sh
 clean:


### PR DESCRIPTION
Do not override compiler settings provided by the user.
Use CXX instead of Cxx variable. Use CXXFLAGS instead of CFLAGS because
we are using C++ compiler (instead of C compiler).